### PR TITLE
#8 subscribeToMore subscription is stopped automatically

### DIFF
--- a/client-app/src/App.js
+++ b/client-app/src/App.js
@@ -60,7 +60,9 @@ class App extends Component {
   };
 
   componentWillUnmount = () => {
-    this.onUnsubscribe();
+    // The subscribeToMore subscription is stopped automatically when its dependent query is stopped,
+    // so we don’t need to unsubscribe manually. 
+    // this.onUnsubscribe();
   };
 
   updateQuery = (prev, {subscriptionData}) => {


### PR DESCRIPTION
#8
http://dev.apollodata.com/react/receiving-updates.html#Subscriptions

The subscribeToMore subscription is stopped automatically when its dependent query is stopped, so we don’t need to unsubscribe manually. We do however need to unsubscribe manually if the props changed and we need to make a new subscription with different variables.

So unsubscribe is not needed in componentWillUnmount().